### PR TITLE
Allow non-signed http requests

### DIFF
--- a/lib/ex_binance/private.ex
+++ b/lib/ex_binance/private.ex
@@ -1,12 +1,12 @@
 defmodule ExBinance.Private do
-  import ExBinance.Rest.HTTPClient, only: [get_auth: 3]
+  import ExBinance.Rest.HTTPClient, only: [get: 3]
 
   @type credentials :: ExBinance.Credentials.t()
   @type shared_errors :: ExBinance.Rest.HTTPClient.shared_errors()
 
   @spec account(credentials) :: {:ok, term} | {:error, shared_errors}
   def account(credentials) do
-    with {:ok, data} <- get_auth("/api/v3/account", %{}, credentials) do
+    with {:ok, data} <- get("/api/v3/account", %{}, credentials) do
       {:ok, ExBinance.Account.new(data)}
     end
   end
@@ -30,5 +30,4 @@ defmodule ExBinance.Private do
               to: ExBinance.Rest.CancelOrder
 
   defdelegate cancel_all_orders(symbol, credentials), to: ExBinance.Rest.CancelAllOrders
-
 end

--- a/lib/ex_binance/rest/http_client.ex
+++ b/lib/ex_binance/rest/http_client.ex
@@ -76,9 +76,9 @@ defmodule ExBinance.Rest.HTTPClient do
     HTTPoison.request(method, "#{endpoint()}#{path}", body, headers)
   end
 
-  defp maybe_sign_params(params, _api_key, false), do: params
+  defp maybe_sign_params(params, _secret_key, false), do: params
 
-  defp maybe_sign_params(params, api_key, true) do
+  defp maybe_sign_params(params, secret_key, true) do
     timestamp = DateTime.utc_now() |> DateTime.to_unix(:millisecond)
 
     params =
@@ -87,7 +87,7 @@ defmodule ExBinance.Rest.HTTPClient do
       |> Map.put(:timestamp, timestamp)
 
     query_string = URI.encode_query(params)
-    signature = sign(api_key, query_string)
+    signature = sign(secret_key, query_string)
 
     Map.put(params, :signature, signature)
   end

--- a/lib/ex_binance/rest/http_client.ex
+++ b/lib/ex_binance/rest/http_client.ex
@@ -46,7 +46,7 @@ defmodule ExBinance.Rest.HTTPClient do
   @spec delete(String.t(), map, credentials) :: {:ok, any} | {:error, shared_errors}
   def delete(path, params, %Credentials{} = credentials) when is_map(params) do
     :delete
-    |> request(path, params, %Credentials{} = credentials)
+    |> request(path, params, credentials)
     |> parse_response()
   end
 
@@ -75,7 +75,6 @@ defmodule ExBinance.Rest.HTTPClient do
     query_string = URI.encode_query(params)
     signature = sign(credentials.api_key, query_string)
 
-    # get request
     body = params |> Map.put(:signature, signature) |> URI.encode_query()
     headers = [{@api_key_header, credentials.api_key}]
 

--- a/test/ex_binance/rest/http_client_test.exs
+++ b/test/ex_binance/rest/http_client_test.exs
@@ -43,10 +43,9 @@ defmodule ExBinance.Rest.HTTPClientTest do
     secret_key: System.get_env("BINANCE_API_SECRET")
   }
 
-  test ".get_auth returns an ok tuple with decoded json data for endpoints that require auth" do
+  test ".get returns an ok tuple with decoded json data for endpoints that require auth" do
     use_cassette "get_auth_ok" do
-      assert {:ok, data} =
-               ExBinance.Rest.HTTPClient.get_auth("/api/v3/account", %{}, @credentials)
+      assert {:ok, data} = ExBinance.Rest.HTTPClient.get("/api/v3/account", %{}, @credentials)
 
       assert %{"canTrade" => _} = data
     end


### PR DESCRIPTION
This PR changes the following:

* consolidate the logic for making requests in the private function `request/4`. 
* drop `get_auth/3` for a more flexible version of `get/4`. 
* make it possible to set the `recvWindow` parameter yourself which was being clobbered in the previous version.
* add options to all http functions that allow the signing of requests to be turned off.

Fixes #47 